### PR TITLE
Add function to get list items by contactId

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,6 +184,11 @@ var RelateIQ = (function() {
     makeRequest('lists/' + listId + '/listitems/' + listItemId, {}, cb);
   };
 
+  RelateIQ.prototype.getListItemsByContactId = function(listId, contactIds, cb) {
+    contactIds = [].concat(contactIds);
+    makeRequest('lists/' + listId + '/listitems?contactIds=' + contactIds.join(','), {}, cb);
+  };
+
   RelateIQ.prototype.createListItem = function(listId, listItem, cb) {
     if (!listItem.accountId && !listItem.contactIds) {
       return cb(new Error('accountId or contactIds is required'));

--- a/test/test.js
+++ b/test/test.js
@@ -89,6 +89,19 @@ describe('AllTests', function() {
     });
   });
 
+  it('should get a list by listId', function(done) {
+    relateIQ.getList(listId, function(err, list) {
+      assert.ifError(err);
+      print(err, list);
+
+      assert.ok(list.id);
+
+      assert.equal(list.id, listId);
+
+      done();
+    });
+  });
+
   it('should create a list item', function(done) {
     relateIQ.createListItem(listId, {
       listId: listId,
@@ -106,6 +119,19 @@ describe('AllTests', function() {
       assert.equal(data.accountId, accountId);
 
       listItemId = data.id;
+
+      done();
+    });
+  });
+
+  it('should fetch a list item by contactId', function(done) {
+    relateIQ.getListItemsByContactId(listId, contactId, function(err, listItems) {
+      assert.ifError(err);
+      print(err, listItems);
+
+      assert.ok(listItems);
+      assert.equal(listItems.length, 1);
+      assert.equal(listItems[0].id, listItemId);
 
       done();
     });


### PR DESCRIPTION
@sjlu - this is a poorly documented RelateIQ API but makes looking up list items by contactId way more efficient.  RelateIQ support got back to be after my last PR with this method.

Squashed and added tests this time.